### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ To make use of the active states, the following CSS classes can be used:
 <script src="bower_components/angular-touch/angular-touch.js"></script>
 <script src="bower_components/fastclick/lib/fastclick.js"></script>
 <script src="bower_components/stateful-fastclick/dist/stateful-fastclick.js"></script>
-<script src="bower_components/angular-fastclick/lib/angular-fastclick.js"></script>
+<script src="bower_components/angular-stateful-fastclick/lib/angular-stateful-fastclick.js"></script>
 ```


### PR DESCRIPTION
A very simple fix to update references of angular-fastclick to angular-stateful-fastclick in the README. I found this a little confusing when I went to `bowser install angular-fastclick --save` and it didn't work.

I could add a quick bit of standard install information at the top if you'd like?
